### PR TITLE
Add fillable properties to models

### DIFF
--- a/app/Models/AppConfig.php
+++ b/app/Models/AppConfig.php
@@ -6,5 +6,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class AppConfig extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'setting',
+        'value',
+    ];
 }

--- a/app/Models/Bandwidth.php
+++ b/app/Models/Bandwidth.php
@@ -6,5 +6,13 @@ use Illuminate\Database\Eloquent\Model;
 
 class Bandwidth extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'name_bw',
+        'rate_down',
+        'rate_down_unit',
+        'rate_up',
+        'rate_up_unit',
+        'burst',
+    ];
 }

--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -6,5 +6,18 @@ use Illuminate\Database\Eloquent\Model;
 
 class Coupon extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'code',
+        'type',
+        'value',
+        'description',
+        'max_usage',
+        'usage_count',
+        'status',
+        'min_order_amount',
+        'max_discount_amount',
+        'start_date',
+        'end_date',
+    ];
 }

--- a/app/Models/Customer.php
+++ b/app/Models/Customer.php
@@ -6,5 +6,29 @@ use Illuminate\Database\Eloquent\Model;
 
 class Customer extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'username',
+        'password',
+        'photo',
+        'pppoe_username',
+        'pppoe_password',
+        'pppoe_ip',
+        'fullname',
+        'address',
+        'city',
+        'district',
+        'state',
+        'zip',
+        'phonenumber',
+        'email',
+        'coordinates',
+        'account_type',
+        'balance',
+        'service_type',
+        'auto_renewal',
+        'status',
+        'created_by',
+        'last_login',
+    ];
 }

--- a/app/Models/CustomerField.php
+++ b/app/Models/CustomerField.php
@@ -6,5 +6,10 @@ use Illuminate\Database\Eloquent\Model;
 
 class CustomerField extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'customer_id',
+        'field_name',
+        'field_value',
+    ];
 }

--- a/app/Models/CustomerInbox.php
+++ b/app/Models/CustomerInbox.php
@@ -6,5 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class CustomerInbox extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'customer_id',
+        'date_created',
+        'date_read',
+        'subject',
+        'body',
+        'from',
+        'admin_id',
+    ];
 }

--- a/app/Models/Log.php
+++ b/app/Models/Log.php
@@ -6,5 +6,12 @@ use Illuminate\Database\Eloquent\Model;
 
 class Log extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'date',
+        'type',
+        'description',
+        'userid',
+        'ip',
+    ];
 }

--- a/app/Models/Meta.php
+++ b/app/Models/Meta.php
@@ -6,5 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Meta extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'tbl',
+        'tbl_id',
+        'name',
+        'value',
+    ];
 }

--- a/app/Models/PaymentGateway.php
+++ b/app/Models/PaymentGateway.php
@@ -6,5 +6,26 @@ use Illuminate\Database\Eloquent\Model;
 
 class PaymentGateway extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'username',
+        'user_id',
+        'gateway',
+        'gateway_trx_id',
+        'plan_id',
+        'plan_name',
+        'routers_id',
+        'routers',
+        'price',
+        'pg_url_payment',
+        'payment_method',
+        'payment_channel',
+        'pg_request',
+        'pg_paid_response',
+        'expired_date',
+        'created_date',
+        'paid_date',
+        'trx_invoice',
+        'status',
+    ];
 }

--- a/app/Models/Plan.php
+++ b/app/Models/Plan.php
@@ -6,5 +6,32 @@ use Illuminate\Database\Eloquent\Model;
 
 class Plan extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'name_plan',
+        'id_bw',
+        'price',
+        'price_old',
+        'type',
+        'typebp',
+        'limit_type',
+        'time_limit',
+        'time_unit',
+        'data_limit',
+        'data_unit',
+        'validity',
+        'validity_unit',
+        'shared_users',
+        'routers',
+        'is_radius',
+        'pool',
+        'plan_expired',
+        'expired_date',
+        'enabled',
+        'prepaid',
+        'plan_type',
+        'device',
+        'on_login',
+        'on_logout',
+    ];
 }

--- a/app/Models/Pool.php
+++ b/app/Models/Pool.php
@@ -6,5 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class Pool extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'pool_name',
+        'local_ip',
+        'range_ip',
+        'routers',
+    ];
 }

--- a/app/Models/PortPool.php
+++ b/app/Models/PortPool.php
@@ -6,5 +6,11 @@ use Illuminate\Database\Eloquent\Model;
 
 class PortPool extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'public_ip',
+        'port_name',
+        'range_port',
+        'routers',
+    ];
 }

--- a/app/Models/RadiusAccount.php
+++ b/app/Models/RadiusAccount.php
@@ -6,5 +6,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class RadiusAccount extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'acctsessionid',
+        'username',
+        'realm',
+        'nasid',
+        'nasipaddress',
+        'nasportid',
+        'nasporttype',
+        'framedipaddress',
+        'acctsessiontime',
+        'acctinputoctets',
+        'acctoutputoctets',
+        'acctstatustype',
+        'macaddr',
+        'dateAdded',
+    ];
 }

--- a/app/Models/Router.php
+++ b/app/Models/Router.php
@@ -6,5 +6,17 @@ use Illuminate\Database\Eloquent\Model;
 
 class Router extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'name',
+        'ip_address',
+        'username',
+        'password',
+        'description',
+        'coordinates',
+        'status',
+        'last_seen',
+        'coverage',
+        'enabled',
+    ];
 }

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -6,5 +6,21 @@ use Illuminate\Database\Eloquent\Model;
 
 class Transaction extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'invoice',
+        'username',
+        'user_id',
+        'plan_name',
+        'price',
+        'recharged_on',
+        'recharged_time',
+        'expiration',
+        'time',
+        'method',
+        'routers',
+        'type',
+        'note',
+        'admin_id',
+    ];
 }

--- a/app/Models/UserRecharge.php
+++ b/app/Models/UserRecharge.php
@@ -6,5 +6,20 @@ use Illuminate\Database\Eloquent\Model;
 
 class UserRecharge extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'customer_id',
+        'username',
+        'plan_id',
+        'namebp',
+        'recharged_on',
+        'recharged_time',
+        'expiration',
+        'time',
+        'status',
+        'method',
+        'routers',
+        'type',
+        'admin_id',
+    ];
 }

--- a/app/Models/Voucher.php
+++ b/app/Models/Voucher.php
@@ -6,5 +6,15 @@ use Illuminate\Database\Eloquent\Model;
 
 class Voucher extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'type',
+        'routers',
+        'id_plan',
+        'code',
+        'user',
+        'status',
+        'used_date',
+        'generated_by',
+    ];
 }

--- a/app/Models/Widget.php
+++ b/app/Models/Widget.php
@@ -6,5 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class Widget extends Model
 {
-    //
+    /** @var list<string> */
+    protected $fillable = [
+        'orders',
+        'position',
+        'user',
+        'enabled',
+        'title',
+        'widget',
+        'content',
+    ];
 }


### PR DESCRIPTION
## Summary
- implement `$fillable` attributes for all domain models
- reference table columns from migrations to allow mass assignment

## Testing
- `composer test` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686cd92dbd4c832c8d17be2e807ace46