### PR TITLE
Add CRM leads module

### DIFF
--- a/app/Http/Controllers/LeadController.php
+++ b/app/Http/Controllers/LeadController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Lead;
+use Illuminate\Http\Request;
+
+class LeadController extends Controller
+{
+    public function index()
+    {
+        $leads = Lead::orderBy('created_at', 'desc')->paginate(20);
+        return view('admin.leads.index', compact('leads'));
+    }
+
+    public function create()
+    {
+        return view('admin.leads.create');
+    }
+
+    public function store(Request $request)
+    {
+        $request->validate([
+            'name' => 'required|string|max:128',
+            'email' => 'nullable|email|max:128',
+            'phone' => 'nullable|string|max:32',
+            'status' => 'required|in:New,Contacted,Qualified,Lost,Customer',
+            'notes' => 'nullable|string',
+        ]);
+
+        Lead::create($request->only(['name', 'email', 'phone', 'status', 'notes']));
+
+        return redirect()->route('admin.leads.index')->with('success', 'Lead created successfully.');
+    }
+
+    public function edit($id)
+    {
+        $lead = Lead::findOrFail($id);
+        return view('admin.leads.edit', compact('lead'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        $lead = Lead::findOrFail($id);
+
+        $request->validate([
+            'name' => 'required|string|max:128',
+            'email' => 'nullable|email|max:128',
+            'phone' => 'nullable|string|max:32',
+            'status' => 'required|in:New,Contacted,Qualified,Lost,Customer',
+            'notes' => 'nullable|string',
+        ]);
+
+        $lead->update($request->only(['name', 'email', 'phone', 'status', 'notes']));
+
+        return redirect()->route('admin.leads.index')->with('success', 'Lead updated successfully.');
+    }
+
+    public function destroy($id)
+    {
+        $lead = Lead::findOrFail($id);
+        $lead->delete();
+
+        return redirect()->route('admin.leads.index')->with('success', 'Lead deleted successfully.');
+    }
+}

--- a/app/Models/Lead.php
+++ b/app/Models/Lead.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Lead extends Model
+{
+    /** @var list<string> */
+    protected $fillable = [
+        'name',
+        'email',
+        'phone',
+        'status',
+        'notes',
+    ];
+}

--- a/database/migrations/2025_07_03_050158_create_leads_table.php
+++ b/database/migrations/2025_07_03_050158_create_leads_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('leads', function (Blueprint $table) {
+            $table->id();
+            $table->string('name', 128);
+            $table->string('email', 128)->nullable();
+            $table->string('phone', 32)->nullable();
+            $table->enum('status', ['New', 'Contacted', 'Qualified', 'Lost', 'Customer'])->default('New');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('leads');
+    }
+};

--- a/resources/views/admin/leads/create.blade.php
+++ b/resources/views/admin/leads/create.blade.php
@@ -1,0 +1,39 @@
+@extends('layouts.app')
+
+@section('page-title', 'Add Lead')
+
+@section('content')
+<div class="card">
+    <div class="card-body">
+        <form action="{{ route('admin.leads.store') }}" method="POST">
+            @csrf
+            <div class="mb-3">
+                <label class="form-label">Name</label>
+                <input type="text" name="name" class="form-control" value="{{ old('name') }}" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Email</label>
+                <input type="email" name="email" class="form-control" value="{{ old('email') }}">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Phone</label>
+                <input type="text" name="phone" class="form-control" value="{{ old('phone') }}">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Status</label>
+                <select name="status" class="form-select">
+                    @foreach(['New','Contacted','Qualified','Lost','Customer'] as $status)
+                        <option value="{{ $status }}" @selected(old('status') === $status)>{{ $status }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Notes</label>
+                <textarea name="notes" class="form-control" rows="3">{{ old('notes') }}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+            <a href="{{ route('admin.leads.index') }}" class="btn btn-secondary">Cancel</a>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/leads/edit.blade.php
+++ b/resources/views/admin/leads/edit.blade.php
@@ -1,0 +1,40 @@
+@extends('layouts.app')
+
+@section('page-title', 'Edit Lead')
+
+@section('content')
+<div class="card">
+    <div class="card-body">
+        <form action="{{ route('admin.leads.update', $lead->id) }}" method="POST">
+            @csrf
+            @method('PUT')
+            <div class="mb-3">
+                <label class="form-label">Name</label>
+                <input type="text" name="name" class="form-control" value="{{ old('name', $lead->name) }}" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Email</label>
+                <input type="email" name="email" class="form-control" value="{{ old('email', $lead->email) }}">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Phone</label>
+                <input type="text" name="phone" class="form-control" value="{{ old('phone', $lead->phone) }}">
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Status</label>
+                <select name="status" class="form-select">
+                    @foreach(['New','Contacted','Qualified','Lost','Customer'] as $status)
+                        <option value="{{ $status }}" @selected(old('status', $lead->status) === $status)>{{ $status }}</option>
+                    @endforeach
+                </select>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Notes</label>
+                <textarea name="notes" class="form-control" rows="3">{{ old('notes', $lead->notes) }}</textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Update</button>
+            <a href="{{ route('admin.leads.index') }}" class="btn btn-secondary">Cancel</a>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/leads/index.blade.php
+++ b/resources/views/admin/leads/index.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.app')
+
+@section('page-title', 'Leads')
+
+@section('content')
+<div class="card">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <h3 class="card-title mb-0">Leads</h3>
+        <a href="{{ route('admin.leads.create') }}" class="btn btn-primary btn-sm">Add Lead</a>
+    </div>
+    <div class="card-body p-0">
+        <table class="table mb-0">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Phone</th>
+                    <th>Status</th>
+                    <th class="text-end">Actions</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($leads as $lead)
+                    <tr>
+                        <td>{{ $lead->name }}</td>
+                        <td>{{ $lead->email }}</td>
+                        <td>{{ $lead->phone }}</td>
+                        <td>{{ $lead->status }}</td>
+                        <td class="text-end">
+                            <a href="{{ route('admin.leads.edit', $lead->id) }}" class="btn btn-sm btn-secondary">Edit</a>
+                            <form action="{{ route('admin.leads.destroy', $lead->id) }}" method="POST" class="d-inline-block" onsubmit="return confirm('Delete this lead?');">
+                                @csrf
+                                @method('DELETE')
+                                <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+                            </form>
+                        </td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    </div>
+    @if($leads->hasPages())
+        <div class="card-footer">
+            {{ $leads->links() }}
+        </div>
+    @endif
+</div>
+@endsection

--- a/resources/views/layouts/admin-sidebar.blade.php
+++ b/resources/views/layouts/admin-sidebar.blade.php
@@ -127,6 +127,31 @@
                     </a>
                 </li>
 
+                <!-- CRM -->
+                <li class="nav-item {{ request()->routeIs('admin.leads.*') ? 'menu-open' : '' }}">
+                    <a href="#" class="nav-link {{ request()->routeIs('admin.leads.*') ? 'active' : '' }}">
+                        <i class="nav-icon fas fa-address-book"></i>
+                        <p>
+                            CRM
+                            <i class="right fas fa-angle-left"></i>
+                        </p>
+                    </a>
+                    <ul class="nav nav-treeview">
+                        <li class="nav-item">
+                            <a href="{{ route('admin.leads.index') }}" class="nav-link {{ request()->routeIs('admin.leads.index') ? 'active' : '' }}">
+                                <i class="far fa-circle nav-icon"></i>
+                                <p>Leads</p>
+                            </a>
+                        </li>
+                        <li class="nav-item">
+                            <a href="{{ route('admin.leads.create') }}" class="nav-link {{ request()->routeIs('admin.leads.create') ? 'active' : '' }}">
+                                <i class="far fa-circle nav-icon"></i>
+                                <p>Add Lead</p>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
+
                 <!-- Settings -->
                 <li class="nav-item">
                     <a href="{{ route('admin.settings.index') }}" class="nav-link {{ request()->routeIs('admin.settings.*') ? 'active' : '' }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -82,6 +82,16 @@ Route::prefix('admin')->middleware(['admin.auth'])->group(function () {
         Route::put('/{id}', [RouterController::class, 'update'])->name('update');
         Route::delete('/{id}', [RouterController::class, 'destroy'])->name('destroy');
     });
+
+    // CRM - Lead management
+    Route::prefix('leads')->name('admin.leads.')->group(function () {
+        Route::get('/', [\App\Http\Controllers\LeadController::class, 'index'])->name('index');
+        Route::get('/create', [\App\Http\Controllers\LeadController::class, 'create'])->name('create');
+        Route::post('/', [\App\Http\Controllers\LeadController::class, 'store'])->name('store');
+        Route::get('/{id}/edit', [\App\Http\Controllers\LeadController::class, 'edit'])->name('edit');
+        Route::put('/{id}', [\App\Http\Controllers\LeadController::class, 'update'])->name('update');
+        Route::delete('/{id}', [\App\Http\Controllers\LeadController::class, 'destroy'])->name('destroy');
+    });
     
     // Transaction management
     Route::prefix('transactions')->name('admin.transactions.')->group(function () {

--- a/tests/Feature/LeadControllerTest.php
+++ b/tests/Feature/LeadControllerTest.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class LeadControllerTest extends TestCase
+{
+    public function test_leads_index_page_loads(): void
+    {
+        $response = $this->withoutMiddleware()->get('/admin/leads');
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
## Summary
- add Lead model
- add LeadController with CRUD features
- add migrations for leads table
- create views for managing leads
- expose CRM menu in admin sidebar
- wire Lead routes
- add feature test for leads index

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ce9e76384832c9a0d6e7882ae093d