### PR TITLE
Add support ticket module

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -9,6 +9,7 @@ use App\Models\Plan;
 use App\Models\Transaction;
 use App\Models\Router;
 use App\Models\UserRecharge;
+use App\Models\Ticket;
 
 class DashboardController extends Controller
 {
@@ -36,7 +37,11 @@ class DashboardController extends Controller
             ->limit(5)
             ->get();
 
-        return view('customer.dashboard', compact('customer', 'activePlan', 'recentTransactions'));
+        $openTickets = Ticket::where('customer_id', $customerId)
+            ->where('status', 'open')
+            ->count();
+
+        return view('customer.dashboard', compact('customer', 'activePlan', 'recentTransactions', 'openTickets'));
     }
 
     public function adminDashboard()
@@ -62,13 +67,22 @@ class DashboardController extends Controller
             ->whereYear('created_at', now()->year)
             ->sum('price');
 
+        $openTickets = Ticket::where('status', 'open')->count();
+        $inProgressTickets = Ticket::where('status', 'in_progress')->count();
+        $pendingTickets = Ticket::where('status', 'pending')->count();
+        $closedTickets = Ticket::where('status', 'closed')->count();
+
         return view('admin.dashboard', compact(
-            'totalCustomers', 
-            'activeCustomers', 
-            'totalPlans', 
+            'totalCustomers',
+            'activeCustomers',
+            'totalPlans',
             'totalRouters',
             'recentTransactions',
-            'monthlyRevenue'
+            'monthlyRevenue',
+            'openTickets',
+            'inProgressTickets',
+            'pendingTickets',
+            'closedTickets'
         ));
     }
 }

--- a/app/Http/Controllers/TicketController.php
+++ b/app/Http/Controllers/TicketController.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Session;
+use App\Models\Ticket;
+
+class TicketController extends Controller
+{
+    public function index()
+    {
+        $tickets = Ticket::orderBy('created_at', 'desc')->paginate(20);
+        return view('admin.tickets.index', compact('tickets'));
+    }
+
+    public function customerIndex()
+    {
+        $customerId = Session::get('customer_id');
+        if (!$customerId) {
+            return redirect()->route('login');
+        }
+
+        $tickets = Ticket::where('customer_id', $customerId)
+            ->orderBy('created_at', 'desc')
+            ->paginate(20);
+
+        return view('customer.tickets.index', compact('tickets'));
+    }
+
+    public function create()
+    {
+        $customerId = Session::get('customer_id');
+        if (!$customerId) {
+            return redirect()->route('login');
+        }
+
+        return view('customer.tickets.create');
+    }
+
+    public function store(Request $request)
+    {
+        $customerId = Session::get('customer_id');
+        if (!$customerId) {
+            return redirect()->route('login');
+        }
+
+        $request->validate([
+            'subject' => 'required|string',
+            'message' => 'required|string',
+        ]);
+
+        Ticket::create([
+            'customer_id' => $customerId,
+            'subject' => $request->subject,
+            'message' => $request->message,
+            'status' => 'open',
+        ]);
+
+        return redirect()->route('customer.tickets.index')
+            ->with('success', 'Ticket created successfully.');
+    }
+
+    public function updateStatus(Request $request, $id)
+    {
+        $request->validate([
+            'status' => 'required|in:open,in_progress,pending,closed',
+        ]);
+
+        $ticket = Ticket::findOrFail($id);
+        $ticket->status = $request->status;
+        $ticket->save();
+
+        return back()->with('success', 'Ticket status updated.');
+    }
+}

--- a/app/Models/Ticket.php
+++ b/app/Models/Ticket.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Ticket extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'customer_id',
+        'subject',
+        'message',
+        'status',
+    ];
+
+    public function customer()
+    {
+        return $this->belongsTo(Customer::class);
+    }
+}

--- a/database/migrations/2025_07_03_050158_create_tickets_table.php
+++ b/database/migrations/2025_07_03_050158_create_tickets_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tickets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('customer_id')->constrained('customers')->cascadeOnDelete();
+            $table->string('subject');
+            $table->text('message');
+            $table->enum('status', ['open', 'in_progress', 'pending', 'closed'])->default('open');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tickets');
+    }
+};

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -75,6 +75,65 @@
 </div>
 
 <div class="row">
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-primary">
+            <div class="inner">
+                <h3>{{ $openTickets }}</h3>
+                <p>Open Tickets</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-folder-open"></i>
+            </div>
+            <a href="{{ route('admin.tickets.index', ['status' => 'open']) }}" class="small-box-footer">
+                More info <i class="fas fa-arrow-circle-right"></i>
+            </a>
+        </div>
+    </div>
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-warning">
+            <div class="inner">
+                <h3>{{ $inProgressTickets }}</h3>
+                <p>Tickets In Progress</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-spinner"></i>
+            </div>
+            <a href="{{ route('admin.tickets.index', ['status' => 'in_progress']) }}" class="small-box-footer">
+                More info <i class="fas fa-arrow-circle-right"></i>
+            </a>
+        </div>
+    </div>
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-secondary">
+            <div class="inner">
+                <h3>{{ $pendingTickets }}</h3>
+                <p>Pending Tickets</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-clock"></i>
+            </div>
+            <a href="{{ route('admin.tickets.index', ['status' => 'pending']) }}" class="small-box-footer">
+                More info <i class="fas fa-arrow-circle-right"></i>
+            </a>
+        </div>
+    </div>
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-success">
+            <div class="inner">
+                <h3>{{ $closedTickets }}</h3>
+                <p>Closed Tickets</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-check"></i>
+            </div>
+            <a href="{{ route('admin.tickets.index', ['status' => 'closed']) }}" class="small-box-footer">
+                More info <i class="fas fa-arrow-circle-right"></i>
+            </a>
+        </div>
+    </div>
+</div>
+
+<div class="row">
     <!-- Recent Transactions -->
     <div class="col-md-8">
         <div class="card">

--- a/resources/views/admin/tickets/index.blade.php
+++ b/resources/views/admin/tickets/index.blade.php
@@ -1,0 +1,57 @@
+@extends('layouts.app')
+
+@section('title', 'Support Tickets')
+@section('page-title', 'Support Tickets')
+
+@section('breadcrumb')
+    <li class="breadcrumb-item"><a href="{{ route('admin.dashboard') }}">Dashboard</a></li>
+    <li class="breadcrumb-item active">Tickets</li>
+@endsection
+
+@section('content')
+<div class="card">
+    <div class="card-body table-responsive p-0">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Customer</th>
+                    <th>Subject</th>
+                    <th>Status</th>
+                    <th>Created</th>
+                    <th>Action</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($tickets as $ticket)
+                    <tr>
+                        <td>{{ $ticket->id }}</td>
+                        <td>{{ $ticket->customer->username ?? 'N/A' }}</td>
+                        <td>{{ $ticket->subject }}</td>
+                        <td>{{ ucfirst(str_replace('_', ' ', $ticket->status)) }}</td>
+                        <td>{{ $ticket->created_at->format('M d, Y') }}</td>
+                        <td>
+                            <form action="{{ route('admin.tickets.updateStatus', $ticket->id) }}" method="POST" class="d-inline">
+                                @csrf
+                                <select name="status" onchange="this.form.submit()" class="form-select form-select-sm">
+                                    <option value="open" {{ $ticket->status=='open' ? 'selected' : '' }}>Open</option>
+                                    <option value="in_progress" {{ $ticket->status=='in_progress' ? 'selected' : '' }}>In Progress</option>
+                                    <option value="pending" {{ $ticket->status=='pending' ? 'selected' : '' }}>Pending</option>
+                                    <option value="closed" {{ $ticket->status=='closed' ? 'selected' : '' }}>Closed</option>
+                                </select>
+                            </form>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="6" class="text-center">No tickets found</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="card-footer clearfix">
+        {{ $tickets->links() }}
+    </div>
+</div>
+@endsection

--- a/resources/views/customer/dashboard.blade.php
+++ b/resources/views/customer/dashboard.blade.php
@@ -1,0 +1,41 @@
+@extends('layouts.app')
+
+@section('title', 'Customer Dashboard')
+@section('page-title', 'Dashboard')
+
+@section('breadcrumb')
+    <li class="breadcrumb-item active">Dashboard</li>
+@endsection
+
+@section('content')
+<div class="row">
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-primary">
+            <div class="inner">
+                <h3>{{ $openTickets ?? 0 }}</h3>
+                <p>Open Tickets</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-folder-open"></i>
+            </div>
+            <a href="{{ route('customer.tickets.index') }}" class="small-box-footer">
+                More info <i class="fas fa-arrow-circle-right"></i>
+            </a>
+        </div>
+    </div>
+    <div class="col-lg-3 col-6">
+        <div class="small-box bg-success">
+            <div class="inner">
+                <h3>{{ $activePlan ? $activePlan->plan_name : 'N/A' }}</h3>
+                <p>Current Plan</p>
+            </div>
+            <div class="icon">
+                <i class="fas fa-signal"></i>
+            </div>
+            <a href="{{ route('customer.plans') }}" class="small-box-footer">
+                More info <i class="fas fa-arrow-circle-right"></i>
+            </a>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/customer/tickets/create.blade.php
+++ b/resources/views/customer/tickets/create.blade.php
@@ -1,0 +1,29 @@
+@extends('layouts.app')
+
+@section('title', 'Open Ticket')
+@section('page-title', 'Open Ticket')
+
+@section('breadcrumb')
+    <li class="breadcrumb-item"><a href="{{ route('customer.dashboard') }}">Dashboard</a></li>
+    <li class="breadcrumb-item"><a href="{{ route('customer.tickets.index') }}">Tickets</a></li>
+    <li class="breadcrumb-item active">Open Ticket</li>
+@endsection
+
+@section('content')
+<div class="card">
+    <div class="card-body">
+        <form action="{{ route('customer.tickets.store') }}" method="POST">
+            @csrf
+            <div class="mb-3">
+                <label class="form-label">Subject</label>
+                <input type="text" name="subject" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Message</label>
+                <textarea name="message" class="form-control" rows="5" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Submit</button>
+        </form>
+    </div>
+</div>
+@endsection

--- a/resources/views/customer/tickets/index.blade.php
+++ b/resources/views/customer/tickets/index.blade.php
@@ -1,0 +1,48 @@
+@extends('layouts.app')
+
+@section('title', 'My Tickets')
+@section('page-title', 'My Tickets')
+
+@section('breadcrumb')
+    <li class="breadcrumb-item"><a href="{{ route('customer.dashboard') }}">Dashboard</a></li>
+    <li class="breadcrumb-item active">Tickets</li>
+@endsection
+
+@section('content')
+<div class="mb-3">
+    <a href="{{ route('customer.tickets.create') }}" class="btn btn-primary">
+        <i class="fas fa-plus me-1"></i> Open Ticket
+    </a>
+</div>
+<div class="card">
+    <div class="card-body table-responsive p-0">
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>Subject</th>
+                    <th>Status</th>
+                    <th>Created</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse($tickets as $ticket)
+                    <tr>
+                        <td>{{ $ticket->id }}</td>
+                        <td>{{ $ticket->subject }}</td>
+                        <td>{{ ucfirst(str_replace('_', ' ', $ticket->status)) }}</td>
+                        <td>{{ $ticket->created_at->format('M d, Y') }}</td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="4" class="text-center">No tickets found</td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
+    </div>
+    <div class="card-footer clearfix">
+        {{ $tickets->links() }}
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/admin-sidebar.blade.php
+++ b/resources/views/layouts/admin-sidebar.blade.php
@@ -119,6 +119,14 @@
                     </a>
                 </li>
 
+                <!-- Support Tickets -->
+                <li class="nav-item">
+                    <a href="{{ route('admin.tickets.index') }}" class="nav-link {{ request()->routeIs('admin.tickets.*') ? 'active' : '' }}">
+                        <i class="nav-icon fas fa-life-ring"></i>
+                        <p>Support Tickets</p>
+                    </a>
+                </li>
+
                 <!-- Reports -->
                 <li class="nav-item">
                     <a href="{{ route('admin.reports.index') }}" class="nav-link {{ request()->routeIs('admin.reports.*') ? 'active' : '' }}">

--- a/resources/views/layouts/customer-header.blade.php
+++ b/resources/views/layouts/customer-header.blade.php
@@ -1,0 +1,15 @@
+<nav class="main-header navbar navbar-expand navbar-white navbar-light">
+    <ul class="navbar-nav">
+        <li class="nav-item">
+            <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
+        </li>
+        <li class="nav-item d-none d-sm-inline-block">
+            <a href="{{ route('customer.dashboard') }}" class="nav-link">Home</a>
+        </li>
+    </ul>
+    <ul class="navbar-nav ml-auto">
+        <li class="nav-item">
+            <a href="{{ route('logout') }}" class="nav-link">Logout</a>
+        </li>
+    </ul>
+</nav>

--- a/resources/views/layouts/customer-sidebar.blade.php
+++ b/resources/views/layouts/customer-sidebar.blade.php
@@ -1,0 +1,24 @@
+<aside class="main-sidebar sidebar-dark-primary elevation-4">
+    <a href="{{ route('customer.dashboard') }}" class="brand-link">
+        <img src="{{ asset('images/logo.png') }}" alt="PHPNuxBill Logo" class="brand-image img-circle elevation-3" style="opacity: .8">
+        <span class="brand-text font-weight-light">PHPNuxBill</span>
+    </a>
+    <div class="sidebar">
+        <nav class="mt-2">
+            <ul class="nav nav-pills nav-sidebar flex-column" data-widget="treeview" role="menu" data-accordion="false">
+                <li class="nav-item">
+                    <a href="{{ route('customer.dashboard') }}" class="nav-link {{ request()->routeIs('customer.dashboard') ? 'active' : '' }}">
+                        <i class="nav-icon fas fa-tachometer-alt"></i>
+                        <p>Dashboard</p>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="{{ route('customer.tickets.index') }}" class="nav-link {{ request()->routeIs('customer.tickets.*') ? 'active' : '' }}">
+                        <i class="nav-icon fas fa-life-ring"></i>
+                        <p>Support Tickets</p>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+</aside>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\VoucherController;
 use App\Http\Controllers\PaymentController;
 use App\Http\Controllers\AdminController;
 use App\Http\Controllers\ReportController;
+use App\Http\Controllers\TicketController;
 
 /*
 |--------------------------------------------------------------------------
@@ -44,6 +45,10 @@ Route::middleware(['customer.auth'])->group(function () {
     Route::get('/customer/transactions', [TransactionController::class, 'customerTransactions'])->name('customer.transactions');
     Route::get('/customer/vouchers', [VoucherController::class, 'customerVouchers'])->name('customer.vouchers');
     Route::post('/customer/voucher/activate', [VoucherController::class, 'activateVoucher'])->name('customer.voucher.activate');
+
+    Route::get('/customer/tickets', [TicketController::class, 'customerIndex'])->name('customer.tickets.index');
+    Route::get('/customer/tickets/create', [TicketController::class, 'create'])->name('customer.tickets.create');
+    Route::post('/customer/tickets', [TicketController::class, 'store'])->name('customer.tickets.store');
 });
 
 // Admin routes
@@ -97,6 +102,11 @@ Route::prefix('admin')->middleware(['admin.auth'])->group(function () {
         Route::post('/', [VoucherController::class, 'store'])->name('store');
         Route::get('/{id}', [VoucherController::class, 'show'])->name('show');
         Route::delete('/{id}', [VoucherController::class, 'destroy'])->name('destroy');
+    });
+
+    Route::prefix('tickets')->name('admin.tickets.')->group(function () {
+        Route::get('/', [TicketController::class, 'index'])->name('index');
+        Route::post('/{id}/status', [TicketController::class, 'updateStatus'])->name('updateStatus');
     });
     
     // Payment management


### PR DESCRIPTION
## Summary
- create Ticket model and migration
- implement TicketController for admin and customer
- display ticket counts on dashboards
- add Support Tickets sidebar entry
- add ticket listing and creation views
- add simple customer layout components

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ced301418832cabe147f2cbe76e6f